### PR TITLE
Integrate news crew with backend database and API

### DIFF
--- a/backend/alembic/versions/ff56ae82308f_add_crew_results_table.py
+++ b/backend/alembic/versions/ff56ae82308f_add_crew_results_table.py
@@ -1,0 +1,37 @@
+"""add_crew_results_table
+
+Revision ID: ff56ae82308f
+Revises: add_language_field
+Create Date: 2024-11-23 16:05:06.129884
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ff56ae82308f'
+down_revision: Union[str, None] = 'add_language_field'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'crew_results',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('article_id', sa.Integer(), nullable=True),
+        sa.Column('parsed_data', sa.Text(), nullable=True),
+        sa.Column('enriched_data', sa.Text(), nullable=True),
+        sa.Column('ranked_data', sa.Text(), nullable=True),
+        sa.Column('final_content', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.current_timestamp(), nullable=True),
+        sa.ForeignKeyConstraint(['article_id'], ['news_articles.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('crew_results')

--- a/backend/src/app/models.py
+++ b/backend/src/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Text, func, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, Text, func, ForeignKey, JSON
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -33,3 +33,17 @@ class NewsArticle(Base):
     created_at = Column(DateTime, server_default=func.now())
     
     audio_file = relationship("AudioFile", back_populates="article", uselist=False)
+    crew_result = relationship("CrewResult", back_populates="article", uselist=False)
+
+class CrewResult(Base):
+    __tablename__ = "crew_results"
+    
+    id = Column(Integer, primary_key=True)
+    article_id = Column(Integer, ForeignKey('news_articles.id'))
+    parsed_data = Column(JSON)  # From ev_news_parsed.json
+    enriched_data = Column(JSON)  # From ev_news_enriched.json
+    ranked_data = Column(JSON)  # From ev_news_ranked.json
+    final_content = Column(Text)  # From ev_news_final.md
+    created_at = Column(DateTime, server_default=func.now())
+    
+    article = relationship("NewsArticle", back_populates="crew_result")

--- a/backend/src/app/news_crew_service.py
+++ b/backend/src/app/news_crew_service.py
@@ -13,7 +13,7 @@ class NewsCrewService:
         self.output_dir = os.path.join(os.path.dirname(__file__), "..", "..", "news_crew", "src", "news_crew", "output")
         os.makedirs(self.output_dir, exist_ok=True)
 
-    async def run_crew(self):
+    async def run_crew(self, article_id=None):
         """Run the news crew to fetch and process news"""
         try:
             # Run the crew
@@ -21,6 +21,9 @@ class NewsCrewService:
                 'rss_url1': 'https://rss.app/feeds/u6rcvfy6PTSf9vQ4.xml',
                 'rss_url2': 'https://rss.feedspot.com/uk_car_rss_feeds/'
             }
+            if article_id:
+                inputs['article_id'] = article_id
+
             self.crew.crew().kickoff(inputs=inputs)
 
             # Read all output files
@@ -48,68 +51,86 @@ class NewsCrewService:
                         crew_data[file_type] = f.read()
 
             # Save to database
-            await self._save_to_db(crew_data['enriched'], crew_data)
+            await self._save_to_db(crew_data['enriched'], crew_data, article_id)
 
         except Exception as e:
             logger.error(f"Error running news crew: {str(e)}")
             raise
 
-    async def _save_to_db(self, news_data, crew_data):
+    async def _save_to_db(self, news_data, crew_data, article_id=None):
         """Save the news data and crew results to the database"""
         async with get_db() as db:
-            for article_data in news_data:
+            if article_id:
+                # Process single article
                 try:
-                    # Create a unique GUID from the article URL
-                    guid = article_data.get('link', article_data.get('url'))
-                    if not guid:
+                    # Create crew result object for existing article
+                    crew_result = CrewResult(
+                        article_id=article_id,
+                        parsed_data=json.dumps(crew_data.get('parsed', [])),
+                        enriched_data=json.dumps(crew_data.get('enriched', [])),
+                        ranked_data=json.dumps(crew_data.get('ranked', [])),
+                        final_content=crew_data.get('final', '')
+                    )
+                    db.add(crew_result)
+                    await db.commit()
+                except Exception as e:
+                    logger.error(f"Error saving crew result for article {article_id}: {str(e)}")
+                    raise
+            else:
+                # Process multiple articles
+                for article_data in news_data:
+                    try:
+                        # Create a unique GUID from the article URL
+                        guid = article_data.get('link', article_data.get('url'))
+                        if not guid:
+                            continue
+
+                        # Parse the publication date
+                        published_str = article_data.get('published')
+                        if published_str:
+                            try:
+                                published_at = parse_date(published_str)
+                            except:
+                                published_at = datetime.utcnow()
+                        else:
+                            published_at = datetime.utcnow()
+
+                        # Create article object
+                        article = NewsArticle(
+                            guid=guid,
+                            title=article_data.get('title'),
+                            description=article_data.get('summary', ''),
+                            content=article_data.get('content', ''),
+                            link=article_data.get('link') or article_data.get('url'),
+                            category='Technology',  # Default category for news crew articles
+                            published_at=published_at
+                        )
+
+                        # Check if article already exists
+                        from sqlalchemy import select
+                        stmt = select(NewsArticle).where(NewsArticle.guid == article.guid)
+                        result = await db.execute(stmt)
+                        existing = result.scalar_one_or_none()
+
+                        if not existing:
+                            logger.info(f"Adding new article from news crew: {article.title}")
+                            db.add(article)
+                            await db.flush()  # Flush to get the article ID
+                            
+                            # Create crew result object
+                            crew_result = CrewResult(
+                                article_id=article.id,
+                                parsed_data=json.dumps(crew_data.get('parsed', [])),
+                                enriched_data=json.dumps(crew_data.get('enriched', [])),
+                                ranked_data=json.dumps(crew_data.get('ranked', [])),
+                                final_content=crew_data.get('final', '')
+                            )
+                            db.add(crew_result)
+                        else:
+                            logger.debug(f"Article from news crew already exists: {article.title}")
+
+                    except Exception as e:
+                        logger.error(f"Error saving article: {str(e)}")
                         continue
 
-                    # Parse the publication date
-                    published_str = article_data.get('published')
-                    if published_str:
-                        try:
-                            published_at = parse_date(published_str)
-                        except:
-                            published_at = datetime.utcnow()
-                    else:
-                        published_at = datetime.utcnow()
-
-                    # Create article object
-                    article = NewsArticle(
-                        guid=guid,
-                        title=article_data.get('title'),
-                        description=article_data.get('summary', ''),
-                        content=article_data.get('content', ''),
-                        link=article_data.get('link') or article_data.get('url'),
-                        category='Technology',  # Default category for news crew articles
-                        published_at=published_at
-                    )
-
-                    # Check if article already exists
-                    from sqlalchemy import select
-                    stmt = select(NewsArticle).where(NewsArticle.guid == article.guid)
-                    result = await db.execute(stmt)
-                    existing = result.scalar_one_or_none()
-
-                    if not existing:
-                        logger.info(f"Adding new article from news crew: {article.title}")
-                        db.add(article)
-                        await db.flush()  # Flush to get the article ID
-                        
-                        # Create crew result object
-                        crew_result = CrewResult(
-                            article_id=article.id,
-                            parsed_data=json.dumps(crew_data.get('parsed', [])),
-                            enriched_data=json.dumps(crew_data.get('enriched', [])),
-                            ranked_data=json.dumps(crew_data.get('ranked', [])),
-                            final_content=crew_data.get('final', '')
-                        )
-                        db.add(crew_result)
-                    else:
-                        logger.debug(f"Article from news crew already exists: {article.title}")
-
-                except Exception as e:
-                    logger.error(f"Error saving article: {str(e)}")
-                    continue
-
-            await db.commit()
+                await db.commit()

--- a/backend/src/app/schemas.py
+++ b/backend/src/app/schemas.py
@@ -1,12 +1,23 @@
 from pydantic import BaseModel
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict, List, Any
 
 class AudioFileResponse(BaseModel):
     id: int
     filename: str
     text_content: str
     duration: Optional[int] = None
+    created_at: datetime
+    
+    class Config:
+        from_attributes = True
+
+class CrewResultResponse(BaseModel):
+    id: int
+    parsed_data: Optional[List[Dict[str, Any]]] = None
+    enriched_data: Optional[List[Dict[str, Any]]] = None
+    ranked_data: Optional[List[Dict[str, Any]]] = None
+    final_content: Optional[str] = None
     created_at: datetime
     
     class Config:
@@ -24,6 +35,7 @@ class NewsResponse(BaseModel):
     views: int
     shares: int
     audio_file: Optional[AudioFileResponse] = None
+    crew_result: Optional[CrewResultResponse] = None
     
     class Config:
         from_attributes = True


### PR DESCRIPTION
This PR adds backend integration for the news crew:

- Added CrewResult model to store crew results
- Created migration for crew_results table
- Updated news crew service to save results
- Added crew results to NewsResponse schema
- Added new endpoint /api/news/{article_id}/crew

The frontend can now:
1. Get crew results along with article data
2. Get crew results directly from dedicated endpoint