### PR TITLE
fix: audio player behavior and API base URL

### DIFF
--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { API_BASE_URL } from '../services/api';
 import { News } from '../types/news';
 import PlayButton from './PlayButton';
 
@@ -20,7 +21,7 @@ const NewsCard: React.FC<NewsCardProps> = ({ news, onPlayClick }) => {
                 {news.image_url && (
                     <div className="relative h-48">
                         <img
-                            src={news.image_url}
+                            src={news.image_url.startsWith('http') ? news.image_url : `${API_BASE_URL}${news.image_url}`}
                             alt={news.title}
                             className="w-full h-full object-cover"
                         />

--- a/src/components/NewsDetail.tsx
+++ b/src/components/NewsDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { API_BASE_URL } from '../services/api';
 import { ArrowLeft, Clock, Share2, Eye } from 'lucide-react';
 import { NewsArticle } from '../types/news';
 import PlayButton from './PlayButton';
@@ -12,7 +13,7 @@ interface NewsDetailProps {
 }
 
 export default function NewsDetail({ article, onBack, relatedArticles }: NewsDetailProps) {
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(true);
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8 mb-24">
@@ -27,7 +28,7 @@ export default function NewsDetail({ article, onBack, relatedArticles }: NewsDet
       <article>
         <div className="relative">
           <img
-            src={article.image_url}
+            src={article.image_url.startsWith('http') ? article.image_url : `${API_BASE_URL}${article.image_url}`}
             alt={article.title}
             className="aspect-video w-full rounded-xl object-cover"
           />
@@ -101,7 +102,7 @@ export default function NewsDetail({ article, onBack, relatedArticles }: NewsDet
             >
               <div className="aspect-video overflow-hidden">
                 <img
-                  src={related.image_url}
+                  src={related.image_url.startsWith('http') ? related.image_url : `${API_BASE_URL}${related.image_url}`}
                   alt={related.title}
                   className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-110"
                 />

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -21,7 +21,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ videoSrc, articles }) => {
       AudioService.pause();
       videoRef.current?.pause();
     } else if (audioMetadata) {
-      AudioService.play(AudioService.getAudioUrl(audioMetadata.filename));
+      AudioService.play(AudioService.getAudioUrl(audioMetadata.filename), currentArticle.id, 'description');
       videoRef.current?.play();
     }
     setIsPlaying(!isPlaying);
@@ -51,7 +51,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ videoSrc, articles }) => {
           
           // Play audio and video
           const audioUrl = AudioService.getAudioUrl(metadata.filename);
-          AudioService.play(audioUrl);
+          AudioService.play(audioUrl, currentArticle.id, 'description');
           videoRef.current?.play();
           setIsPlaying(true);
         }
@@ -107,7 +107,7 @@ const VideoPlayer: React.FC<VideoPlayerProps> = ({ videoSrc, articles }) => {
 
         // Create a user interaction event handler
         const handleUserInteraction = () => {
-          AudioService.play(audioUrl);
+          AudioService.play(audioUrl, currentArticle.id, 'description');
           // Remove the event listeners after first interaction
           document.removeEventListener("click", handleUserInteraction);
           document.removeEventListener("touchstart", handleUserInteraction);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,5 @@
 export const API_BASE_URL =
-  import.meta.env.VITE_API_URL || "http://127.0.0.1:8000/api";
+  import.meta.env.VITE_API_URL || "http://127.0.0.1:8000";
 
 export interface FetchArticlesParams {
   category?: string;
@@ -25,7 +25,7 @@ export async function fetchArticles(params: FetchArticlesParams = {}) {
     }
   }
 
-  const response = await fetch(`${API_BASE_URL}/news?${queryParams}`);
+  const response = await fetch(`${API_BASE_URL}/api/news?${queryParams}`);
   if (!response.ok) {
     throw new Error(`Failed to fetch articles: ${response.statusText}`);
   }
@@ -33,7 +33,7 @@ export async function fetchArticles(params: FetchArticlesParams = {}) {
 }
 
 export async function incrementViews(id: number) {
-  const response = await fetch(`${API_BASE_URL}/news/${id}/view`, {
+  const response = await fetch(`${API_BASE_URL}/api/news/${id}/view`, {
     method: "POST",
   });
   if (!response.ok) {
@@ -43,7 +43,7 @@ export async function incrementViews(id: number) {
 }
 
 export async function incrementShares(id: number) {
-  const response = await fetch(`${API_BASE_URL}/news/${id}/share`, {
+  const response = await fetch(`${API_BASE_URL}/api/news/${id}/share`, {
     method: "POST",
   });
   if (!response.ok) {


### PR DESCRIPTION
1. Changed API_BASE_URL to not include /api suffix
2. Added /api prefix to all API endpoints
3. Added base URL prefix for image URLs
4. Improved audio player behavior:
   - Only one audio source can play at a time
   - Reset UI when new audio starts
   - Auto-show player in NewsDetail
   - Added proper cleanup for event listeners